### PR TITLE
Unmarshal a single Device when registering

### DIFF
--- a/appstoreconnect/devices.go
+++ b/appstoreconnect/devices.go
@@ -71,6 +71,12 @@ type DevicesResponse struct {
 	Links PagedDocumentLinks `json:"links,omitempty"`
 }
 
+// DeviceResponse ...
+type DeviceResponse struct {
+	Data  Device           `json:"data"`
+	Links PagedDocumentLinks `json:"links,omitempty"`
+}
+
 // ListDevices ...
 func (s ProvisioningService) ListDevices(opt *ListDevicesOptions) (*DevicesResponse, error) {
 	if err := opt.UpdateCursor(); err != nil {
@@ -114,13 +120,13 @@ type DeviceCreateRequest struct {
 }
 
 // RegisterNewDevice ...
-func (s ProvisioningService) RegisterNewDevice(body DeviceCreateRequest) (*DevicesResponse, error) {
+func (s ProvisioningService) RegisterNewDevice(body DeviceCreateRequest) (*DeviceResponse, error) {
 	req, err := s.client.NewRequest(http.MethodPost, DevicesEndpoint, body)
 	if err != nil {
 		return nil, err
 	}
 
-	r := &DevicesResponse{}
+	r := &DeviceResponse{}
 	if _, err := s.client.Do(req, r); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I've encountered #13 earlier today after adding four new devices on bitrise.io, and noticed something in the error log: a JSON unmarshalling problem of the successful response kills the step, while the request was actually successful in the background.

According to the [documentation of the RegisterNewDevice endpoint](https://developer.apple.com/documentation/appstoreconnectapi/register_a_new_device), successful calls return a DeviceResponse (singular) instead of a DevicesResponse. The former has a single Device instead of an array in the JSON, and that explains everything.

So, I added the DeviceResponse type and used that in RegisterNewDevice.
This fixes #13 (tested on bitrise.io).