### PR TITLE
Correctly use expiry function for profile

### DIFF
--- a/autoprovision/profilehelper.go
+++ b/autoprovision/profilehelper.go
@@ -192,17 +192,17 @@ func checkProfileDevices(client *appstoreconnect.Client, prof appstoreconnect.Pr
 	return true, nil
 }
 
-func checkProfileExpired(prof appstoreconnect.Profile, minProfileDaysValid int) bool {
+func isProfileExpired(prof appstoreconnect.Profile, minProfileDaysValid int) bool {
 	relativeExpiryTime := time.Now()
 	if minProfileDaysValid > 0 {
 		relativeExpiryTime = relativeExpiryTime.Add(time.Duration(minProfileDaysValid) * 24 * time.Hour)
 	}
-	return !time.Time(prof.Attributes.ExpirationDate).After(relativeExpiryTime)
+	return time.Time(prof.Attributes.ExpirationDate).Before(relativeExpiryTime)
 }
 
 // CheckProfile ...
 func CheckProfile(client *appstoreconnect.Client, prof appstoreconnect.Profile, entitlements Entitlement, deviceIDs, certificateIDs []string, minProfileDaysValid int) (bool, error) {
-	if !checkProfileExpired(prof, minProfileDaysValid) {
+	if isProfileExpired(prof, minProfileDaysValid) {
 		return false, nil
 	}
 

--- a/autoprovision/profilehelper_test.go
+++ b/autoprovision/profilehelper_test.go
@@ -191,7 +191,7 @@ func Test_checkProfileExpiry(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := checkProfileExpired(tt.prof, tt.minProfileDaysValid); got != tt.want {
+			if got := isProfileExpired(tt.prof, tt.minProfileDaysValid); got != tt.want {
 				t.Errorf("checkProfileExpiry() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
The `checkProfileExpired ` was confusingly named, and because of that incorrectly checked.