### PR TITLE
STEP 13 contacts notes entitlement

### DIFF
--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -102,7 +102,7 @@ func (c *Client) NewRequest(method, endpoint string, body interface{}) (*http.Re
 	endpoint = apiVersion + "/" + endpoint
 	u, err := c.BaseURL.Parse(endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("parsing endpoint failed, %v", err)
+		return nil, fmt.Errorf("parsing endpoint failed: %v", err)
 	}
 
 	var buf io.ReadWriter
@@ -111,13 +111,13 @@ func (c *Client) NewRequest(method, endpoint string, body interface{}) (*http.Re
 		enc := json.NewEncoder(buf)
 		enc.SetEscapeHTML(false)
 		if err := enc.Encode(body); err != nil {
-			return nil, fmt.Errorf("encoding body failed, %v", err)
+			return nil, fmt.Errorf("encoding body failed: %v", err)
 		}
 	}
 
 	req, err := http.NewRequest(method, u.String(), buf)
 	if err != nil {
-		return nil, fmt.Errorf("preparing request failed, %v", err)
+		return nil, fmt.Errorf("preparing request failed: %v", err)
 	}
 
 	if body != nil {
@@ -127,7 +127,7 @@ func (c *Client) NewRequest(method, endpoint string, body interface{}) (*http.Re
 	if _, ok := c.client.(*http.Client); ok {
 		signedToken, err := c.ensureSignedToken()
 		if err != nil {
-			return nil, fmt.Errorf("ensuring JWT token failed, %v", err)
+			return nil, fmt.Errorf("ensuring JWT token failed: %v", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+signedToken)
 	}

--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -102,7 +102,7 @@ func (c *Client) NewRequest(method, endpoint string, body interface{}) (*http.Re
 	endpoint = apiVersion + "/" + endpoint
 	u, err := c.BaseURL.Parse(endpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing endpoint failed, %v", err)
 	}
 
 	var buf io.ReadWriter
@@ -111,13 +111,13 @@ func (c *Client) NewRequest(method, endpoint string, body interface{}) (*http.Re
 		enc := json.NewEncoder(buf)
 		enc.SetEscapeHTML(false)
 		if err := enc.Encode(body); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encoding body failed, %v", err)
 		}
 	}
 
 	req, err := http.NewRequest(method, u.String(), buf)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("preparing request failed, %v", err)
 	}
 
 	if body != nil {
@@ -127,7 +127,7 @@ func (c *Client) NewRequest(method, endpoint string, body interface{}) (*http.Re
 	if _, ok := c.client.(*http.Client); ok {
 		signedToken, err := c.ensureSignedToken()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("ensuring JWT token failed, %v", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+signedToken)
 	}

--- a/appstoreconnect/capabilities.go
+++ b/appstoreconnect/capabilities.go
@@ -77,8 +77,8 @@ var ServiceTypeByKey = map[string]CapabilityType{
 	// does not appear on developer portal
 	"com.apple.developer.icloud-container-identifiers":   Ignored,
 	"com.apple.developer.ubiquity-container-identifiers": Ignored,
-	// UnsupportedEntitlements contains entitlements not supported via the API and this step,
-	// profile needs to be manually generated on Apple Developer Portal
+	// These are entitlements not supported via the API and this step,
+	// profile needs to be manually generated on Apple Developer Portal.
 	"com.apple.developer.contacts.notes":         ProfileAttachedEntitlement,
 	"com.apple.developer.carplay-audio":          ProfileAttachedEntitlement,
 	"com.apple.developer.carplay-communication":  ProfileAttachedEntitlement,

--- a/appstoreconnect/capabilities.go
+++ b/appstoreconnect/capabilities.go
@@ -78,6 +78,18 @@ var ServiceTypeByKey = map[string]CapabilityType{
 	"com.apple.developer.ubiquity-container-identifiers": Ignored,
 }
 
+// UnsupportedEntitlements contains entitlements not supported via the API and this step,
+// profile needs to be manually generated on Apple Developer Portal
+var UnsupportedEntitlements = []string{
+	"com.apple.developer.contacts.notes",
+	"com.apple.developer.carplay-audio",
+	"com.apple.developer.carplay-communication",
+	"com.apple.developer.carplay-charging",
+	"com.apple.developer.carplay-maps",
+	"com.apple.developer.carplay-parking",
+	"com.apple.developer.carplay-quick-ordering",
+}
+
 // CapabilitySettingAllowedInstances ...
 type CapabilitySettingAllowedInstances string
 

--- a/appstoreconnect/capabilities.go
+++ b/appstoreconnect/capabilities.go
@@ -14,6 +14,7 @@ type CapabilityType string
 // CapabilityTypes ...
 const (
 	Ignored                        CapabilityType = "-ignored-"
+	ProfileAttachedEntitlement     CapabilityType = "-profile-attached-"
 	ICloud                         CapabilityType = "ICLOUD"
 	InAppPurchase                  CapabilityType = "IN_APP_PURCHASE"
 	GameCenter                     CapabilityType = "GAME_CENTER"
@@ -76,18 +77,16 @@ var ServiceTypeByKey = map[string]CapabilityType{
 	// does not appear on developer portal
 	"com.apple.developer.icloud-container-identifiers":   Ignored,
 	"com.apple.developer.ubiquity-container-identifiers": Ignored,
-}
-
-// UnsupportedEntitlements contains entitlements not supported via the API and this step,
-// profile needs to be manually generated on Apple Developer Portal
-var UnsupportedEntitlements = []string{
-	"com.apple.developer.contacts.notes",
-	"com.apple.developer.carplay-audio",
-	"com.apple.developer.carplay-communication",
-	"com.apple.developer.carplay-charging",
-	"com.apple.developer.carplay-maps",
-	"com.apple.developer.carplay-parking",
-	"com.apple.developer.carplay-quick-ordering",
+	// UnsupportedEntitlements contains entitlements not supported via the API and this step,
+	// profile needs to be manually generated on Apple Developer Portal
+	"com.apple.developer.contacts.notes":         ProfileAttachedEntitlement,
+	"com.apple.developer.carplay-audio":          ProfileAttachedEntitlement,
+	"com.apple.developer.carplay-communication":  ProfileAttachedEntitlement,
+	"com.apple.developer.carplay-charging":       ProfileAttachedEntitlement,
+	"com.apple.developer.carplay-maps":           ProfileAttachedEntitlement,
+	"com.apple.developer.carplay-parking":        ProfileAttachedEntitlement,
+	"com.apple.developer.carplay-quick-ordering": ProfileAttachedEntitlement,
+	"com.apple.developer.exposure-notification":  ProfileAttachedEntitlement,
 }
 
 // CapabilitySettingAllowedInstances ...

--- a/appstoreconnect/jwt.go
+++ b/appstoreconnect/jwt.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -18,7 +19,7 @@ func signToken(token *jwt.Token, privateKeyContent []byte) (string, error) {
 	}
 	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to sign JWT token, private key format is invalid: %v", err)
 	}
 
 	privateKey, ok := key.(*ecdsa.PrivateKey)

--- a/autoprovision/entitlements.go
+++ b/autoprovision/entitlements.go
@@ -70,6 +70,19 @@ func dataProtectionEquals(entVal string, cap appstoreconnect.BundleIDCapability)
 	return true, nil
 }
 
+// ContainsUnsupportedEntitlement returns an error if an entitlement is used that we can not generate using the API
+func ContainsUnsupportedEntitlement(entitlementsByBundleID map[string]serialized.Object, unsupportedEntitlements []string) error {
+	for id, entitlements := range entitlementsByBundleID {
+		for entitlement := range entitlements {
+			if sliceutil.IsStringInSlice(entitlement, unsupportedEntitlements) {
+				return fmt.Errorf("unsupported entitlement (%s) set for bundle ID %s", entitlement, id)
+			}
+		}
+	}
+
+	return nil
+}
+
 // AppearsOnDeveloperPortal reports whether the given (project) Entitlement needs to be registered on Apple Developer Portal or not.
 // List of services, to be registered: https://developer.apple.com/documentation/appstoreconnectapi/capabilitytype.
 func (e Entitlement) AppearsOnDeveloperPortal() bool {

--- a/autoprovision/entitlements.go
+++ b/autoprovision/entitlements.go
@@ -70,7 +70,7 @@ func dataProtectionEquals(entVal string, cap appstoreconnect.BundleIDCapability)
 	return true, nil
 }
 
-// CanGenerateProfileWithEntitlement checks all entitlements, wheter they can be generated
+// CanGenerateProfileWithEntitlements checks all entitlements, wheter they can be generated
 func CanGenerateProfileWithEntitlements(entitlementsByBundleID map[string]serialized.Object) (bool, string, string) {
 	for bundleID, entitlements := range entitlementsByBundleID {
 		for entitlementKey, value := range entitlements {

--- a/autoprovision/entitlements.go
+++ b/autoprovision/entitlements.go
@@ -71,7 +71,7 @@ func dataProtectionEquals(entVal string, cap appstoreconnect.BundleIDCapability)
 }
 
 // CanGenerateProfileWithEntitlements checks all entitlements, wheter they can be generated
-func CanGenerateProfileWithEntitlements(entitlementsByBundleID map[string]serialized.Object) (bool, string, string) {
+func CanGenerateProfileWithEntitlements(entitlementsByBundleID map[string]serialized.Object) (ok bool, badEntitlement string, badBundleID string) {
 	for bundleID, entitlements := range entitlementsByBundleID {
 		for entitlementKey, value := range entitlements {
 			if (Entitlement{entitlementKey: value}).IsProfileAttached() {

--- a/autoprovision/entitlements_test.go
+++ b/autoprovision/entitlements_test.go
@@ -107,17 +107,17 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 		name                   string
 		entitlementsByBundleID map[string]serialized.Object
 		want                   bool
-		want1                  string
-		want2                  string
+		wantEntitlement        string
+		wantBundleID           string
 	}{
 		{
 			name: "no entitlements",
 			entitlementsByBundleID: map[string]serialized.Object{
 				"com.bundleid": map[string]interface{}{},
 			},
-			want:  true,
-			want1: "",
-			want2: "",
+			want:            true,
+			wantEntitlement: "",
+			wantBundleID:    "",
 		},
 		{
 			name: "contains unsupported entitlement",
@@ -127,9 +127,9 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 					"com.apple.developer.contacts.notes": true,
 				},
 			},
-			want:  false,
-			want1: "com.apple.developer.contacts.notes",
-			want2: "com.bundleid",
+			want:            false,
+			wantEntitlement: "com.apple.developer.contacts.notes",
+			wantBundleID:    "com.bundleid",
 		},
 		{
 			name: "contains unsupported entitlement, multiple bundle IDs",
@@ -142,9 +142,9 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 					"com.apple.developer.contacts.notes": true,
 				},
 			},
-			want:  false,
-			want1: "com.apple.developer.contacts.notes",
-			want2: "com.bundleid2",
+			want:            false,
+			wantEntitlement: "com.apple.developer.contacts.notes",
+			wantBundleID:    "com.bundleid2",
 		},
 		{
 			name: "all entitlements supported",
@@ -153,22 +153,22 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 					"aps-environment": true,
 				},
 			},
-			want:  true,
-			want1: "",
-			want2: "",
+			want:            true,
+			wantEntitlement: "",
+			wantBundleID:    "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2 := autoprovision.CanGenerateProfileWithEntitlements(tt.entitlementsByBundleID)
+			got, gotEntilement, gotBundleID := autoprovision.CanGenerateProfileWithEntitlements(tt.entitlementsByBundleID)
 			if got != tt.want {
 				t.Errorf("CanGenerateProfileWithEntitlements() got = %v, want %v", got, tt.want)
 			}
-			if got1 != tt.want1 {
-				t.Errorf("CanGenerateProfileWithEntitlements() got1 = %v, want %v", got1, tt.want1)
+			if gotEntilement != tt.wantEntitlement {
+				t.Errorf("CanGenerateProfileWithEntitlements() got1 = %v, want %v", gotEntilement, tt.wantEntitlement)
 			}
-			if got2 != tt.want2 {
-				t.Errorf("CanGenerateProfileWithEntitlements() got2 = %v, want %v", got2, tt.want2)
+			if gotBundleID != tt.wantBundleID {
+				t.Errorf("CanGenerateProfileWithEntitlements() got2 = %v, want %v", gotBundleID, tt.wantBundleID)
 			}
 		})
 	}

--- a/autoprovision/entitlements_test.go
+++ b/autoprovision/entitlements_test.go
@@ -106,7 +106,7 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 	tests := []struct {
 		name                   string
 		entitlementsByBundleID map[string]serialized.Object
-		want                   bool
+		wantOk                 bool
 		wantEntitlement        string
 		wantBundleID           string
 	}{
@@ -115,7 +115,7 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 			entitlementsByBundleID: map[string]serialized.Object{
 				"com.bundleid": map[string]interface{}{},
 			},
-			want:            true,
+			wantOk:          true,
 			wantEntitlement: "",
 			wantBundleID:    "",
 		},
@@ -127,7 +127,7 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 					"com.apple.developer.contacts.notes": true,
 				},
 			},
-			want:            false,
+			wantOk:          false,
 			wantEntitlement: "com.apple.developer.contacts.notes",
 			wantBundleID:    "com.bundleid",
 		},
@@ -142,7 +142,7 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 					"com.apple.developer.contacts.notes": true,
 				},
 			},
-			want:            false,
+			wantOk:          false,
 			wantEntitlement: "com.apple.developer.contacts.notes",
 			wantBundleID:    "com.bundleid2",
 		},
@@ -153,16 +153,16 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 					"aps-environment": true,
 				},
 			},
-			want:            true,
+			wantOk:          true,
 			wantEntitlement: "",
 			wantBundleID:    "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotEntilement, gotBundleID := autoprovision.CanGenerateProfileWithEntitlements(tt.entitlementsByBundleID)
-			if got != tt.want {
-				t.Errorf("CanGenerateProfileWithEntitlements() got = %v, want %v", got, tt.want)
+			gotOk, gotEntilement, gotBundleID := autoprovision.CanGenerateProfileWithEntitlements(tt.entitlementsByBundleID)
+			if gotOk != tt.wantOk {
+				t.Errorf("CanGenerateProfileWithEntitlements() got = %v, want %v", gotOk, tt.wantOk)
 			}
 			if gotEntilement != tt.wantEntitlement {
 				t.Errorf("CanGenerateProfileWithEntitlements() got1 = %v, want %v", gotEntilement, tt.wantEntitlement)

--- a/autoprovision/entitlements_test.go
+++ b/autoprovision/entitlements_test.go
@@ -135,7 +135,7 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 			name: "contains unsupported entitlement, multiple bundle IDs",
 			entitlementsByBundleID: map[string]serialized.Object{
 				"com.bundleid": map[string]interface{}{
-					"com.entitlement-supported": true,
+					"aps-environment": true,
 				},
 				"com.bundleid2": map[string]interface{}{
 					"com.entitlement-ignored":            true,
@@ -150,7 +150,7 @@ func TestCanGenerateProfileWithEntitlements(t *testing.T) {
 			name: "all entitlements supported",
 			entitlementsByBundleID: map[string]serialized.Object{
 				"com.bundleid": map[string]interface{}{
-					"com.entitlement-supported": true,
+					"aps-environment": true,
 				},
 			},
 			want:  true,

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -228,7 +228,8 @@ workflows:
             - content: |-
                 #!/bin/bash
                 set -ex
-                if [[ $SAMPLE_APP_URL =~ "^https" ]]; then
+                MATCH_PATTERN="^https"
+                if [[ $SAMPLE_APP_URL =~ $MATCH_PATTERN ]]; then
                   git clone -b $BRANCH $SAMPLE_APP_URL .
                 else
                   cp -r $SAMPLE_APP_URL .

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,6 +11,13 @@ app:
     - TEAM_ID: $TEAM_ID
     - BITRISE_KEYCHAIN_PASSWORD: $BITRISE_KEYCHAIN_PASSWORD
 
+    # Used for development
+    - LOCAL_SAMPLE_PATH: $LOCAL_SAMPLE_PATH
+    - LOCAL_PROJECT_NAME: $LOCAL_PROJECT_NAME
+    - LOCAL_SCHEME: $LOCAL_SCHEME
+    # If also defined in .bitrise.secrets.yml, that will take precedence
+    - $KEYCHAIN_PATH: $HOME/Library/Keychains/login.keychain
+
     - API_TOKEN: $API_TOKEN
     - APP_SLUG: $APP_SLUG
 
@@ -57,6 +64,17 @@ workflows:
       - test_tvos_development
       - test_tvos_managed
       - test_tvos_development_managed
+
+  debug:
+    envs:
+      - SAMPLE_APP_URL: $LOCAL_SAMPLE_PATH
+      - BITRISE_PROJECT_PATH: $LOCAL_PROJECT_NAME
+      - BITRISE_SCHEME: $LOCAL_SCHEME
+      - BITRISE_CONFIGURATION: Debug
+      - DISTRIBUTION_TYPE: development
+      - GENERATE_PROFILES: "yes"
+    after_run:
+      - _common
 
   test_bundle_id:
     envs:
@@ -209,7 +227,12 @@ workflows:
           inputs:
             - content: |-
                 #!/bin/bash
-                git clone -b $BRANCH $SAMPLE_APP_URL .
+                set -ex
+                if [[ $SAMPLE_APP_URL =~ "^https" ]]; then
+                  git clone -b $BRANCH $SAMPLE_APP_URL .
+                else
+                  cp -r $SAMPLE_APP_URL .
+                fi
       - cocoapods-install:
           run_if: '{{enveq "INSTALL_PODS" "true"}}'
           title: CocoaPods install
@@ -225,6 +248,8 @@ workflows:
             - project_path: $BITRISE_PROJECT_PATH
             - scheme: $BITRISE_SCHEME
             - configuration: $BITRISE_CONFIGURATION
+            - keychain_path: $KEYCHAIN_PATH
+            - keychain_password: $BITRISE_KEYCHAIN_PASSWORD
             - verbose_log: "yes"
       - script:
           title: Output test

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,14 +9,14 @@ app:
     - BITRISE_CERTIFICATE_URL: $BITRISE_CERTIFICATE_URL
     - BITRISE_CERTIFICATE_PASSPHRASE: $BITRISE_CERTIFICATE_PASSPHRASE
     - TEAM_ID: $TEAM_ID
+    - KEYCHAIN_PATH: $HOME/Library/Keychains/login.keychain
     - BITRISE_KEYCHAIN_PASSWORD: $BITRISE_KEYCHAIN_PASSWORD
 
     # Used for development
     - LOCAL_SAMPLE_PATH: $LOCAL_SAMPLE_PATH
     - LOCAL_PROJECT_NAME: $LOCAL_PROJECT_NAME
     - LOCAL_SCHEME: $LOCAL_SCHEME
-    # If also defined in .bitrise.secrets.yml, that will take precedence
-    - $KEYCHAIN_PATH: $HOME/Library/Keychains/login.keychain
+    - $LOCAL_KEYCHAIN_PATH: $LOCAL_KEYCHAIN_PATH
 
     - API_TOKEN: $API_TOKEN
     - APP_SLUG: $APP_SLUG
@@ -73,6 +73,7 @@ workflows:
       - BITRISE_CONFIGURATION: Debug
       - DISTRIBUTION_TYPE: development
       - GENERATE_PROFILES: "yes"
+      - KEYCHAIN_PATH: $LOCAL_KEYCHAIN_PATH
     after_run:
       - _common
 
@@ -208,6 +209,8 @@ workflows:
     - _common
 
   _common:
+    envs:
+      - KEYCHAIN_PATH: $KEYCHAIN_PATH
     steps:
       - script:
           title: Cleanup _tmp dir

--- a/main.go
+++ b/main.go
@@ -385,8 +385,9 @@ func main() {
 		log.Printf("- %s", id)
 	}
 
-	if err := autoprovision.ContainsUnsupportedEntitlement(entitlementsByBundleID, appstoreconnect.UnsupportedEntitlements); err != nil {
-		failf("Error: %v. Generate provisioning profile manually on Apple Developer Portal and use the Certificate and profile installer Step.", err)
+	if ok, entitlement, bundleID := autoprovision.CanGenerateProfileWithEntitlements(entitlementsByBundleID); !ok {
+		log.Errorf("Can not create profile with unsupported entitlement (%s) for the bundle ID %s, due to API limitations.", entitlement, bundleID)
+		failf("Please generate provisioning profile manually on Apple Developer Portal and use the Certificate and profile installer Step instead.")
 	}
 
 	platform, err := projHelper.Platform(config)

--- a/main.go
+++ b/main.go
@@ -385,6 +385,10 @@ func main() {
 		log.Printf("- %s", id)
 	}
 
+	if err := autoprovision.ContainsUnsupportedEntitlement(entitlementsByBundleID, appstoreconnect.UnsupportedEntitlements); err != nil {
+		failf("Error: %v. Generate provisioning profile manually on Apple Developer Portal and use the Certificate and profile installer Step.", err)
+	}
+
 	platform, err := projHelper.Platform(config)
 	if err != nil {
 		failf("Failed to read project platform: %s", err)

--- a/main.go
+++ b/main.go
@@ -386,7 +386,7 @@ func main() {
 	}
 
 	if ok, entitlement, bundleID := autoprovision.CanGenerateProfileWithEntitlements(entitlementsByBundleID); !ok {
-		log.Errorf("Can not create profile with unsupported entitlement (%s) for the bundle ID %s, due to API limitations.", entitlement, bundleID)
+		log.Errorf("Can not create profile with unsupported entitlement (%s) for the bundle ID %s, due to App Store Connect API limitations.", entitlement, bundleID)
 		failf("Please generate provisioning profile manually on Apple Developer Portal and use the Certificate and profile installer Step instead.")
 	}
 


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-13

Adding check whether an unsupported entitlement is used, that we can not add on the API.

- We check this before checking if App ID exist and is valid as as far we know,
these needed to be added in the provisioning profile generation phase.
So even if the user creates App ID manually, the step can not generate the correct profiles.
The extra entitlements require Apple approval, which I could not test,
so choose to fail early and make the user use the Certificates Installer Step.

Discussed with @istvankovacs-bitrise adding this logic to SyncBundleID -> Capabilities at https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/blob/8394b5a0f0f72b4a95728d6e4da3d7463144eeec/autoprovision/entitlements.go#L179, but decided that is not the same use case, as supposedly the user still can generate App ID manually, and the step will use it (may need the check this logic again as did not validate)

Carplay entitlement: https://developer.apple.com/documentation/carplay/requesting_the_carplay_entitlements
Contacts notes entitlement: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes

Other entitlements for reference (not yet checked): https://developer.apple.com/documentation/bundleresources/entitlements