### PR TITLE
Support variable in iCloud Container

### DIFF
--- a/autoprovision/bundleidhelper.go
+++ b/autoprovision/bundleidhelper.go
@@ -45,7 +45,7 @@ func FindBundleID(client *appstoreconnect.Client, bundleIDIdentifier string) (*a
 	return nil, nil
 }
 
-func checkBundleIDEntitlements(bundleIDEntitlements []appstoreconnect.BundleIDCapability, projectEntitlements Entitlement) (bool, string, error) {
+func checkBundleIDEntitlements(bundleIDEntitlements []appstoreconnect.BundleIDCapability, projectEntitlements Entitlement) error {
 	for k, v := range projectEntitlements {
 		ent := Entitlement{k: v}
 
@@ -57,7 +57,7 @@ func checkBundleIDEntitlements(bundleIDEntitlements []appstoreconnect.BundleIDCa
 		for _, cap := range bundleIDEntitlements {
 			equal, err := ent.Equal(cap)
 			if err != nil {
-				return false, "", err
+				return err
 			}
 
 			if equal {
@@ -67,20 +67,20 @@ func checkBundleIDEntitlements(bundleIDEntitlements []appstoreconnect.BundleIDCa
 		}
 
 		if !found {
-			return false, fmt.Sprintf("bundle ID missing Capability (%s) required by project Entitlement (%s)", appstoreconnect.ServiceTypeByKey[k], k), nil
+			return NonmatchingProfileError{
+				Reason: fmt.Sprintf("bundle ID missing Capability (%s) required by project Entitlement (%s)", appstoreconnect.ServiceTypeByKey[k], k),
+			}
 		}
 	}
 
-	return true, "", nil
+	return nil
 }
 
 // CheckBundleIDEntitlements checks if a given Bundle ID has every capability enabled, required by the project.
-func CheckBundleIDEntitlements(client *appstoreconnect.Client, bundleID appstoreconnect.BundleID, projectEntitlements Entitlement) (bool, string, error) {
-	response, err := client.Provisioning.Capabilities(
-		bundleID.Relationships.Capabilities.Links.Related)
-
+func CheckBundleIDEntitlements(client *appstoreconnect.Client, bundleID appstoreconnect.BundleID, projectEntitlements Entitlement) error {
+	response, err := client.Provisioning.Capabilities(bundleID.Relationships.Capabilities.Links.Related)
 	if err != nil {
-		return false, "", err
+		return err
 	}
 
 	return checkBundleIDEntitlements(response.Data, projectEntitlements)

--- a/autoprovision/bundleidhelper.go
+++ b/autoprovision/bundleidhelper.go
@@ -45,7 +45,7 @@ func FindBundleID(client *appstoreconnect.Client, bundleIDIdentifier string) (*a
 	return nil, nil
 }
 
-func checkBundleIDEntitlements(bundleIDEntitlements []appstoreconnect.BundleIDCapability, projectEntitlements Entitlement) (bool, error, string) {
+func checkBundleIDEntitlements(bundleIDEntitlements []appstoreconnect.BundleIDCapability, projectEntitlements Entitlement) (bool, string, error) {
 	for k, v := range projectEntitlements {
 		ent := Entitlement{k: v}
 
@@ -57,7 +57,7 @@ func checkBundleIDEntitlements(bundleIDEntitlements []appstoreconnect.BundleIDCa
 		for _, cap := range bundleIDEntitlements {
 			equal, err := ent.Equal(cap)
 			if err != nil {
-				return false, err, ""
+				return false, "", err
 			}
 
 			if equal {
@@ -67,20 +67,20 @@ func checkBundleIDEntitlements(bundleIDEntitlements []appstoreconnect.BundleIDCa
 		}
 
 		if !found {
-			return false, nil, fmt.Sprintf("bundle ID missing Capability (%s) required by project Entitlement (%s)", appstoreconnect.ServiceTypeByKey[k], k)
+			return false, fmt.Sprintf("bundle ID missing Capability (%s) required by project Entitlement (%s)", appstoreconnect.ServiceTypeByKey[k], k), nil
 		}
 	}
 
-	return true, nil, ""
+	return true, "", nil
 }
 
 // CheckBundleIDEntitlements checks if a given Bundle ID has every capability enabled, required by the project.
-func CheckBundleIDEntitlements(client *appstoreconnect.Client, bundleID appstoreconnect.BundleID, projectEntitlements Entitlement) (bool, error, string) {
+func CheckBundleIDEntitlements(client *appstoreconnect.Client, bundleID appstoreconnect.BundleID, projectEntitlements Entitlement) (bool, string, error) {
 	response, err := client.Provisioning.Capabilities(
 		bundleID.Relationships.Capabilities.Links.Related)
 
 	if err != nil {
-		return false, err, ""
+		return false, "", err
 	}
 
 	return checkBundleIDEntitlements(response.Data, projectEntitlements)

--- a/autoprovision/bundleidhelper_test.go
+++ b/autoprovision/bundleidhelper_test.go
@@ -11,8 +11,9 @@ func Test_checkBundleIDEntitlements(t *testing.T) {
 		name                 string
 		bundleIDEntitlements []appstoreconnect.BundleIDCapability
 		projectEntitlements  Entitlement
-		want                 bool
+		wantOk               bool
 		wantErr              bool
+		wantReason           string
 	}{
 		{
 			name:                 "Check known entitlements, which does not need to be registered on the Developer Portal",
@@ -23,19 +24,23 @@ func Test_checkBundleIDEntitlements(t *testing.T) {
 				"com.apple.developer.icloud-container-identifiers":   "",
 				"com.apple.developer.ubiquity-container-identifiers": "",
 			}),
-			want:    true,
-			wantErr: false,
+			wantOk:     true,
+			wantErr:    false,
+			wantReason: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := checkBundleIDEntitlements(tt.bundleIDEntitlements, tt.projectEntitlements)
+			gotOk, gotReason, err := checkBundleIDEntitlements(tt.bundleIDEntitlements, tt.projectEntitlements)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("checkBundleIDEntitlements() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("checkBundleIDEntitlements() = %v, want %v", got, tt.want)
+			if gotOk != tt.wantOk {
+				t.Errorf("checkBundleIDEntitlements() ok = %v, want %v", gotOk, tt.wantOk)
+			}
+			if gotReason != tt.wantReason {
+				t.Errorf("checkBundleIDEntitlements() reason = %v, want %v", gotReason, tt.wantReason)
 			}
 		})
 	}

--- a/autoprovision/certificatehelper.go
+++ b/autoprovision/certificatehelper.go
@@ -155,7 +155,7 @@ func (e MissingCertificateError) Error() string {
 }
 
 // GetValidCertificates ...
-func GetValidCertificates(localCertificates []certificateutil.CertificateInfoModel, client CertificateSource, requiredCertificateTypes map[appstoreconnect.CertificateType]bool, teamID string) (map[appstoreconnect.CertificateType][]APICertificate, error) {
+func GetValidCertificates(localCertificates []certificateutil.CertificateInfoModel, client CertificateSource, requiredCertificateTypes map[appstoreconnect.CertificateType]bool, teamID string, isDebugLog bool) (map[appstoreconnect.CertificateType][]APICertificate, error) {
 	typeToLocalCerts, err := GetValidLocalCertificates(localCertificates, teamID)
 	if err != nil {
 		return nil, err
@@ -170,8 +170,10 @@ func GetValidCertificates(localCertificates []certificateutil.CertificateInfoMod
 	}
 
 	// only for debugging
-	if err := LogAllAPICertificates(client, typeToLocalCerts); err != nil {
-		log.Debugf("Failed to log all Developer Portal certificates: %s", err)
+	if isDebugLog {
+		if err := LogAllAPICertificates(client, typeToLocalCerts); err != nil {
+			log.Debugf("Failed to log all Developer Portal certificates: %s", err)
+		}
 	}
 
 	validAPICertificates := map[appstoreconnect.CertificateType][]APICertificate{}

--- a/autoprovision/certificatehelper_test.go
+++ b/autoprovision/certificatehelper_test.go
@@ -268,7 +268,7 @@ func TestGetValidCertificates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetValidCertificates(tt.args.localCertificates, tt.args.client, tt.args.requiredCertificateTypes, tt.args.teamID)
+			got, err := GetValidCertificates(tt.args.localCertificates, tt.args.client, tt.args.requiredCertificateTypes, tt.args.teamID, true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetValidCertificates() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/autoprovision/entitlements.go
+++ b/autoprovision/entitlements.go
@@ -20,6 +20,8 @@ var DataProtections = map[string]appstoreconnect.CapabilityOptionKey{
 	"NSFileProtectionCompleteUntilFirstUserAuthentication": appstoreconnect.ProtectedUntilFirstUserAuth,
 }
 
+const iCloudIdentifiersEntitlementKey = "com.apple.developer.icloud-container-identifiers"
+
 func iCloudEquals(ent Entitlement, cap appstoreconnect.BundleIDCapability) (bool, error) {
 	documents, cloudKit, kvStorage, err := ent.iCloudServices()
 	if err != nil {
@@ -167,7 +169,7 @@ func (e Entitlement) ICloudContainers() ([]string, error) {
 		return nil, nil
 	}
 
-	containers, err := serialized.Object(e).StringSlice("com.apple.developer.icloud-container-identifiers")
+	containers, err := serialized.Object(e).StringSlice(iCloudIdentifiersEntitlementKey)
 	if err != nil && !serialized.IsKeyNotFoundError(err) {
 		return nil, err
 	}

--- a/autoprovision/profilehelper.go
+++ b/autoprovision/profilehelper.go
@@ -58,21 +58,6 @@ func checkProfileEntitlements(client *appstoreconnect.Client, prof appstoreconne
 
 	projectEnts := serialized.Object(projectEntitlements)
 
-	// Compare profile and project entitlements
-	for localEnt := range projectEntitlements {
-		found := false
-		for remoteEnt := range profileEnts {
-			if localEnt == remoteEnt {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return false, nil, fmt.Sprintf("project entitlemet (%s) not found in profile", localEnt)
-		}
-	}
-
 	missingContainers, err := findMissingContainers(projectEnts, profileEnts)
 	if err != nil {
 		return false, fmt.Errorf("failed to check missing containers: %s", err), ""

--- a/autoprovision/profilehelper.go
+++ b/autoprovision/profilehelper.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -111,12 +110,6 @@ func findMissingContainers(projectEnts, profileEnts serialized.Object) ([]string
 
 	var missing []string
 	for _, projContainerID := range projContainerIDs {
-		// iCloud container name can contain variables, for example: `iCloud.$(CFBundleIdentifier)`
-		// In that case suppose that the container is set up correctly, as can not resolve variables
-		if strings.ContainsRune(projContainerID, '$') {
-			continue
-		}
-
 		var found bool
 		for _, profContainerID := range profContainerIDs {
 			if projContainerID == profContainerID {

--- a/autoprovision/profilehelper.go
+++ b/autoprovision/profilehelper.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -109,6 +110,12 @@ func findMissingContainers(projectEnts, profileEnts serialized.Object) ([]string
 
 	var missing []string
 	for _, projContainerID := range projContainerIDs {
+		// iCloud container name can contain variables, for example: `iCloud.$(CFBundleIdentifier)`
+		// In that case suppose that the container is set up correctly, as can not resolve variables
+		if strings.ContainsRune(projContainerID, '$') {
+			continue
+		}
+
 		var found bool
 		for _, profContainerID := range profContainerIDs {
 			if projContainerID == profContainerID {

--- a/autoprovision/profilehelper.go
+++ b/autoprovision/profilehelper.go
@@ -64,7 +64,7 @@ func checkProfileEntitlements(client *appstoreconnect.Client, prof appstoreconne
 	}
 
 	if len(missingContainers) > 0 {
-		return false, "", fmt.Errorf("project uses containers that are missing from the provisioning profile: %v", missingContainers)
+		return false, fmt.Sprintf("project uses containers that are missing from the provisioning profile: %v", missingContainers), nil
 	}
 
 	bundleIDresp, err := client.Provisioning.BundleID(prof.Relationships.BundleID.Links.Related)

--- a/autoprovision/profilehelper_test.go
+++ b/autoprovision/profilehelper_test.go
@@ -143,6 +143,18 @@ func Test_findMissingContainers(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "project has more containers, containing env var, they are ignored as resolving them is difficult",
+			projectEnts: serialized.Object(map[string]interface{}{
+				"com.apple.developer.icloud-container-identifiers": []interface{}{"iCloud.$(CFBundleIdentifier)"},
+			}),
+			profileEnts: serialized.Object(map[string]interface{}{
+				"com.apple.developer.icloud-container-identifiers": []interface{}{"iCloud.bundle.id"},
+			}),
+
+			want:    nil,
+			wantErr: false,
+		},
+		{
 			name: "project has containers but profile doesn't",
 			projectEnts: serialized.Object(map[string]interface{}{
 				"com.apple.developer.icloud-container-identifiers": []interface{}{"container1"},

--- a/autoprovision/profilehelper_test.go
+++ b/autoprovision/profilehelper_test.go
@@ -143,18 +143,6 @@ func Test_findMissingContainers(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "project has more containers, containing env var, they are ignored as resolving them is difficult",
-			projectEnts: serialized.Object(map[string]interface{}{
-				"com.apple.developer.icloud-container-identifiers": []interface{}{"iCloud.$(CFBundleIdentifier)"},
-			}),
-			profileEnts: serialized.Object(map[string]interface{}{
-				"com.apple.developer.icloud-container-identifiers": []interface{}{"iCloud.bundle.id"},
-			}),
-
-			want:    nil,
-			wantErr: false,
-		},
-		{
 			name: "project has containers but profile doesn't",
 			projectEnts: serialized.Object(map[string]interface{}{
 				"com.apple.developer.icloud-container-identifiers": []interface{}{"container1"},

--- a/autoprovision/projecthelper.go
+++ b/autoprovision/projecthelper.go
@@ -324,7 +324,8 @@ func codesignIdentitesMatch(identity1, identity2 string) bool {
 }
 
 func expandTargetSetting(value string, buildSettings serialized.Object) (string, error) {
-	r, err := regexp.Compile(`^(.*)[$][({](.+?)([:].+)?[})](.*)$`)
+	regexpStr := `^(.*)[$][({](.+?)([:].+)?[})](.*)$`
+	r, err := regexp.Compile(regexpStr)
 	if err != nil {
 		return "", err
 	}
@@ -332,7 +333,7 @@ func expandTargetSetting(value string, buildSettings serialized.Object) (string,
 	captures := r.FindStringSubmatch(value)
 
 	if len(captures) < 5 {
-		return "", fmt.Errorf("failed to match regex `^(.*)[$][({](.+?)([:].+)?[})](.*)$` to %s target build setting", value)
+		return "", fmt.Errorf("failed to match regex '%s' to %s target build setting", regexpStr, value)
 	}
 
 	prefix := captures[1]

--- a/autoprovision/projecthelper.go
+++ b/autoprovision/projecthelper.go
@@ -86,7 +86,7 @@ func (p *ProjectHelper) ArchivableTargetBundleIDToEntitlements() (map[string]ser
 			return nil, fmt.Errorf("failed to get target (%s) bundle id: %s", target.Name, err)
 		}
 
-		entitlements, err := p.targetEntitlements(target.Name, p.Configuration)
+		entitlements, err := p.targetEntitlements(target.Name, p.Configuration, bundleID)
 		if err != nil && !serialized.IsKeyNotFoundError(err) {
 			return nil, fmt.Errorf("failed to get target (%s) bundle id: %s", target.Name, err)
 		}
@@ -258,7 +258,7 @@ func (p *ProjectHelper) TargetBundleID(name, conf string) (string, error) {
 
 	log.Debugf("CFBundleIdentifier defined with variable: %s, trying to resolve it...", bundleID)
 
-	resolved, err := resolveBundleID(bundleID, settings)
+	resolved, err := expandTargetSetting(bundleID, settings)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve bundle ID: %s", err)
 	}
@@ -268,12 +268,48 @@ func (p *ProjectHelper) TargetBundleID(name, conf string) (string, error) {
 	return resolved, nil
 }
 
-func (p *ProjectHelper) targetEntitlements(name, config string) (serialized.Object, error) {
-	o, err := p.XcProj.TargetCodeSignEntitlements(name, config)
+func (p *ProjectHelper) targetEntitlements(name, config, bundleID string) (serialized.Object, error) {
+	entitlements, err := p.XcProj.TargetCodeSignEntitlements(name, config)
 	if err != nil && !serialized.IsKeyNotFoundError(err) {
 		return nil, err
 	}
-	return o, nil
+
+	return resolveEntitlementVariables(Entitlement(entitlements), bundleID)
+}
+
+// resolveEntitlementVariables expands variables in the project entitlements.
+// Entitlement values can contain variables, for example: `iCloud.$(CFBundleIdentifier)`.
+// Expanding iCloud Container values only, as they are compared to the profile values later.
+// Expand CFBundleIdentifier variable only, other variables are not yet supported.
+func resolveEntitlementVariables(entitlements Entitlement, bundleID string) (serialized.Object, error) {
+	containers, err := entitlements.ICloudContainers()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(containers) == 0 {
+		return serialized.Object(entitlements), nil
+	}
+
+	var expandedContainers []interface{}
+	for _, container := range containers {
+		if strings.ContainsRune(container, '$') {
+			expanded, err := expandTargetSetting(container, serialized.Object{"CFBundleIdentifier": bundleID})
+			if err != nil {
+				log.Warnf("Ignoring iCloud container ID (%s) as can not expand variable: %v", container, err)
+				continue
+			}
+
+			expandedContainers = append(expandedContainers, expanded)
+			continue
+		}
+
+		expandedContainers = append(expandedContainers, container)
+	}
+
+	entitlements[iCloudIdentifiersEntitlementKey] = expandedContainers
+
+	return serialized.Object(entitlements), nil
 }
 
 // 'iPhone Developer' should match to 'iPhone Developer: Bitrise Bot (ABCD)'
@@ -287,28 +323,28 @@ func codesignIdentitesMatch(identity1, identity2 string) bool {
 	return false
 }
 
-func resolveBundleID(bundleID string, buildSettings serialized.Object) (string, error) {
-	r, err := regexp.Compile(".+[.][$][(].+[:].+[)]*")
+func expandTargetSetting(value string, buildSettings serialized.Object) (string, error) {
+	r, err := regexp.Compile(`^(.*)[$][({](.+?)([:].+)?[})](.*)$`)
 	if err != nil {
 		return "", err
 	}
 
-	if !r.MatchString(bundleID) {
-		return "", fmt.Errorf("failed to match regex .+[.][$][(].+[:].+[)]* to %s bundleID", bundleID)
+	captures := r.FindStringSubmatch(value)
+
+	if len(captures) < 5 {
+		return "", fmt.Errorf("failed to match regex `^(.*)[$][({](.+?)([:].+)?[})](.*)$` to %s target build setting", value)
 	}
 
-	captures := r.FindString(bundleID)
-
-	prefix := strings.Split(captures, "$")[0]
-	envKey := strings.Split(strings.SplitAfter(captures, "(")[1], ":")[0]
-	suffix := strings.Join(strings.SplitAfter(captures, ")")[1:], "")
+	prefix := captures[1]
+	envKey := captures[2]
+	suffix := captures[4]
 
 	envValue, err := buildSettings.String(envKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to find environment variable value for key %s: %s", envKey, err)
 	}
-	return prefix + envValue + suffix, nil
 
+	return prefix + envValue + suffix, nil
 }
 
 func configuration(configurationName string, scheme xcscheme.Scheme, xcproj xcodeproj.XcodeProj) (string, error) {

--- a/autoprovision/projecthelper_test.go
+++ b/autoprovision/projecthelper_test.go
@@ -302,7 +302,7 @@ func Test_expandTargetSetting(t *testing.T) {
 				m["CFBundleIdentifier"] = productName
 				return m
 			}(),
-			want:    fmt.Sprintf(productName),
+			want:    productName,
 			wantErr: false,
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -431,7 +431,7 @@ func main() {
 	}
 
 	certClient := autoprovision.APIClient(client)
-	certsByType, err := autoprovision.GetValidCertificates(certs, certClient, requiredCertTypes, teamID)
+	certsByType, err := autoprovision.GetValidCertificates(certs, certClient, requiredCertTypes, teamID, stepConf.VerboseLog)
 	if err != nil {
 		if missingCertErr, ok := err.(autoprovision.MissingCertificateError); ok {
 			log.Errorf(err.Error())

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func (m ProfileManager) EnsureBundleID(bundleIDIdentifier string, entitlements s
 		m.bundleIDByBundleIDIdentifer[bundleIDIdentifier] = bundleID
 
 		// Check if BundleID is sync with the project
-		ok, err, invalidReason := autoprovision.CheckBundleIDEntitlements(m.client, *bundleID, autoprovision.Entitlement(entitlements))
+		ok, invalidReason, err := autoprovision.CheckBundleIDEntitlements(m.client, *bundleID, autoprovision.Entitlement(entitlements))
 		if err != nil {
 			return nil, fmt.Errorf("failed to validate bundle ID: %s", err)
 		}
@@ -235,7 +235,7 @@ func (m ProfileManager) EnsureProfile(profileType appstoreconnect.ProfileType, b
 
 		if profile.Attributes.ProfileState == appstoreconnect.Active {
 			// Check if Bitrise managed Profile is sync with the project
-			ok, err, reason := autoprovision.CheckProfile(m.client, *profile, autoprovision.Entitlement(entitlements), deviceIDs, certIDs, minProfileDaysValid)
+			ok, reason, err := autoprovision.CheckProfile(m.client, *profile, autoprovision.Entitlement(entitlements), deviceIDs, certIDs, minProfileDaysValid)
 			if err != nil {
 				return nil, fmt.Errorf("failed to check if profile is valid: %s", err)
 			}


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-260

iCloud container name can contain variables, for example: `iCloud.$(CFBundleIdentifier)`. The code checks if project entitlements mapped to a capability are present in the App ID on Developer Portal. The iCloud containers are a special case, where the exact container is checked for existence in the App ID. If does not exist, the autoprov step fails as can not create iCloud containers at the moment. 

I only expand this specific variable (CFBundleIdentifier) for now.
Also if the profile is not valid because of missing iCloud container, now will not  fail, but will regenerate the profile.


Added additional logging of the reason if the profile needs to be regenerated, as there were multiple issues with it recently:
- (fixed previously) The expiration was checked inversely
- (This PR fixes it) Disabled devices on Developer Portal cause the profile to be always regenerated. Fixed by listing enabled devices only, to prevent profile regeneration as disabled devices are not added to profiles.


Example entitlements file for reference:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>aps-environment</key>
	<string>development</string>
	<key>com.apple.developer.applesignin</key>
	<array>
		<string>Default</string>
	</array>
	<key>com.apple.developer.icloud-container-identifiers</key>
	<array>
		<string>iCloud.${CFBundleIdentifier}</string>
	</array>
	<key>com.apple.developer.icloud-services</key>
	<array>
		<string>CloudKit</string>
	</array>
</dict>
</plist>
```





