### PR TITLE
Include APPLE_WATCH UDID as a part of IOS provisioning profile

### DIFF
--- a/main.go
+++ b/main.go
@@ -668,8 +668,8 @@ func main() {
 					log.Debugf("dropping device %s, since device type: %s, required device type: APPLE_TV", d.ID, d.Attributes.DeviceClass)
 					continue
 				} else if strings.HasPrefix(string(profileType), "IOS") &&
-					string(d.Attributes.DeviceClass) != "IPHONE" && string(d.Attributes.DeviceClass) != "IPAD" && string(d.Attributes.DeviceClass) != "IPOD" {
-					log.Debugf("dropping device %s, since device type: %s, required device type: IPHONE, IPAD or IPOD", d.ID, d.Attributes.DeviceClass)
+					string(d.Attributes.DeviceClass) != "IPHONE" && string(d.Attributes.DeviceClass) != "IPAD" && string(d.Attributes.DeviceClass) != "IPOD" && string(d.Attributes.DeviceClass) != "APPLE_WATCH" {
+					log.Debugf("dropping device %s, since device type: %s, required device type: IPHONE, IPAD, IPOD or APPLE_WATCH", d.ID, d.Attributes.DeviceClass)
 					continue
 				}
 				deviceIDs = append(deviceIDs, d.ID)


### PR DESCRIPTION


### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires NO [version update](https://semver.org/)

### Context

<!--- One sentence summary on why the change is needed. -->
Watchapps builds from bitrise for ad-hoc distribution does not install because it is dropped from provisioning profiles.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes
- Include APPLE_WATCH as one of the devices to check for in IOS Provisioning profiles
<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
Example logs seen on bitrise:
```
dropping device *******, since device type: APPLE_WATCH, required device type: IPHONE, IPAD or IPOD
```

### Decisions

N/A
<!-- Please list decisions that were made for this change. -->
