### PR TITLE
Token expiration handling improved

### DIFF
--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -84,11 +84,11 @@ func (c *Client) ensureSignedToken() (string, error) {
 		// To get better performance from the App Store Connect API,
 		// reuse the same signed token for up to 20 minutes.
 		//  https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests
-		if expiration.After(time.Now().Add(20 * time.Minute)) {
+		if expiration.After(time.Now().Add(6 * time.Minute)) {
 			return c.signedToken, nil
 		}
 
-		log.Infof("Authentication token is expiring soon (expiration: %s), regenerating.", expiration)
+		log.Printf("Authentication token is expiring soon (expiration: %s), regenerating.", expiration)
 	}
 
 	c.token = createToken(c.keyID, c.issuerID)

--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -87,6 +87,8 @@ func (c *Client) ensureSignedToken() (string, error) {
 		if expiration.After(time.Now().Add(20 * time.Minute)) {
 			return c.signedToken, nil
 		}
+
+		log.Infof("Authentication token is expiring soon (expiration: %s), regenerating.", expiration)
 	}
 
 	c.token = createToken(c.keyID, c.issuerID)

--- a/appstoreconnect/jwt.go
+++ b/appstoreconnect/jwt.go
@@ -35,7 +35,7 @@ func signToken(token *jwt.Token, privateKeyContent []byte) (string, error) {
 func createToken(keyID string, issuerID string) *jwt.Token {
 	payload := claims{
 		IssuerID:   issuerID,
-		Expiration: time.Now().Add(time.Minute * 20).Unix(),
+		Expiration: time.Now().Add(time.Minute * 18).Unix(),
 		Audience:   "appstoreconnect-v1",
 	}
 

--- a/appstoreconnect/jwt.go
+++ b/appstoreconnect/jwt.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/bitrise-io/go-utils/log"
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
@@ -37,6 +38,8 @@ func createToken(keyID string, issuerID string) *jwt.Token {
 		Expiration: time.Now().Add(time.Minute * 20).Unix(),
 		Audience:   "appstoreconnect-v1",
 	}
+
+	log.Debugf("Creating new JWT token: %s", payload)
 
 	// registers headers: alg = ES256 and typ = JWT
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, payload)


### PR DESCRIPTION
### Checklist

- [ ] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MAJOR / MINOR / PATCH_ [version update](https://semver.org/)

### Context

##### Change token reuse logic:

* Do not regenerate tokens in each call, only if token expiry is 6 (4 + 2 cushion minutes) away.
Earlier we regenerated the token if expired less than 20 minutes, and that was true every time as the original token had a 20 minute expiry.
See https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests.

* Generate initial token with 18 minutes expiry (20 - 2 cushion minutes)

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
