### PR TITLE
Step 1218 improve networking reliability

### DIFF
--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -26,7 +26,11 @@ const (
 )
 
 var (
-	jwtDuration    = 20 * time.Minute
+	// A given token can be reused for up to 20 minutes:
+	// https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests
+	//
+	// Using 19 minutes to make sure time inaccuracies at token validation does not cause issues.
+	jwtDuration    = 19 * time.Minute
 	jwtReserveTime = 2 * time.Minute
 )
 

--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -81,7 +81,7 @@ func NewRetryableHTTPClient() *RetryableHTTPClient {
 	client := retryablehttp.NewClient()
 	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
-			log.Debugf("Retry network error: 401")
+			log.Debugf("Received HTTP 401 (Unauthorized), retrying request...")
 			return true, nil
 		}
 

--- a/appstoreconnect/jwt.go
+++ b/appstoreconnect/jwt.go
@@ -34,7 +34,7 @@ func signToken(token *jwt.Token, privateKeyContent []byte) (string, error) {
 func createToken(keyID string, issuerID string) *jwt.Token {
 	payload := claims{
 		IssuerID:   issuerID,
-		Expiration: time.Now().Add(time.Minute * 20).Unix(),
+		Expiration: time.Now().Add(jwtDuration).Unix(),
 		Audience:   "appstoreconnect-v1",
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/stretchr/testify v1.7.0
 	howett.net/plist v0.0.0-20201203080718-1454fab16a06

--- a/main.go
+++ b/main.go
@@ -469,7 +469,8 @@ func main() {
 		failf("Could not configure Apple Service authentication: %v", err)
 	}
 
-	client := appstoreconnect.NewClient(http.DefaultClient, authConfig.APIKey.KeyID, authConfig.APIKey.IssuerID, []byte(authConfig.APIKey.PrivateKey))
+	httpClient := appstoreconnect.NewRetryableHTTPClient()
+	client := appstoreconnect.NewClient(httpClient, authConfig.APIKey.KeyID, authConfig.APIKey.IssuerID, []byte(authConfig.APIKey.PrivateKey))
 
 	// Turn off client debug logs includeing HTTP call debug logs
 	client.EnableDebugLogs = false


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

The Step sporadically fails with 401 NOT_AUTHORIZED error, retry resolves the issue.

Resolves: https://bitrise.atlassian.net/browse/STEP-1218

### Changes

- Resue the JWT token for up to 18 minutes.
  - A given [token can be reused for up to 20 minutes](https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests), 2 minutes reserve time added to avoid token overuse.
- Use [retryablehttp.Client](https://github.com/hashicorp/go-retryablehttp) as HTTPClient and implement custom retry for HTTP status code 401

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
