### PR TITLE
Add config option to disable device registration.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,3 +52,4 @@ workflows:
         - keychain_password: $BITRISE_KEYCHAIN_PASSWORD
         - verbose_log: "yes"
         - sign_uitest_targets: "yes"
+        - register_test_devices: "no"

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Scheme            string `env:"scheme,required"`
 	Configuration     string `env:"configuration"`
 	SignUITestTargets bool   `env:"sign_uitest_targets,opt[yes,no]"`
+	RegisterTestDevices bool `env:"register_test_devices,opt[yes,no]"`
 
 	Distribution        string `env:"distribution_type,opt[development,app-store,ad-hoc,enterprise]"`
 	MinProfileDaysValid int    `env:"min_profile_days_valid"`

--- a/devices.go
+++ b/devices.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/autoprovision"
 )
 
-func needToRegisterDevices(distrTypes []autoprovision.DistributionType) bool {
+func distributionTypeRequiresDeviceList(distrTypes []autoprovision.DistributionType) bool {
 	for _, distrType := range distrTypes {
 		if distrType == autoprovision.Development || distrType == autoprovision.AdHoc {
 			return true

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -41,6 +41,7 @@ workflows:
       - BITRISE_SCHEME: sample-xcode-13-empty
       - BITRISE_CONFIGURATION: Debug
       - SIGN_UITEST_TARGET: "yes"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "false"
       - DISTRIBUTION_TYPE: development
       - CONNECTION: "off"
@@ -79,6 +80,7 @@ workflows:
       - BITRISE_SCHEME: sample-apps-fastlane-test
       - BITRISE_CONFIGURATION: Debug
       - SIGN_UITEST_TARGET: "yes"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "false"
       - DISTRIBUTION_TYPE: development
       - CONNECTION: "off"
@@ -97,6 +99,7 @@ workflows:
       - BITRISE_SCHEME: ios-simple-objc
       - BITRISE_CONFIGURATION: Release
       - SIGN_UITEST_TARGET: "no"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "false"
       - DISTRIBUTION_TYPE: ad-hoc
       - CONNECTION: "off"
@@ -115,6 +118,7 @@ workflows:
       - BITRISE_SCHEME: code-sign-test
       - BITRISE_CONFIGURATION:
       - SIGN_UITEST_TARGET: "no"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "false"
       - DISTRIBUTION_TYPE: app-store
       - CONNECTION: "api_key"
@@ -133,6 +137,7 @@ workflows:
       - BITRISE_SCHEME: code-sign-test
       - BITRISE_CONFIGURATION:
       - SIGN_UITEST_TARGET: "no"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "false"
       - DISTRIBUTION_TYPE: app-store
       - CONNECTION: "automatic"
@@ -159,6 +164,7 @@ workflows:
       - BITRISE_SCHEME: iOSMinimalCocoaPodsSample
       - BITRISE_CONFIGURATION:
       - SIGN_UITEST_TARGET: "no"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "true"
       - DISTRIBUTION_TYPE: app-store
       - CONNECTION: "automatic"
@@ -185,6 +191,7 @@ workflows:
       - BITRISE_SCHEME: NPO Live
       - BITRISE_CONFIGURATION:
       - SIGN_UITEST_TARGET: "no"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "false"
       - DISTRIBUTION_TYPE: app-store
       - CONNECTION: "automatic"
@@ -211,6 +218,7 @@ workflows:
       - BITRISE_SCHEME: NPO Live
       - BITRISE_CONFIGURATION:
       - SIGN_UITEST_TARGET: "no"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "false"
       - DISTRIBUTION_TYPE: development
       - CONNECTION: "automatic"
@@ -240,6 +248,7 @@ workflows:
       - BITRISE_SCHEME: ios-simple-objc
       - BITRISE_CONFIGURATION: Release
       - SIGN_UITEST_TARGET: "no"
+      - REGISTER_TEST_DEVICES: "yes"
       - INSTALL_PODS: "false"
       - DISTRIBUTION_TYPE: app-store
       - CONNECTION: "automatic"
@@ -281,6 +290,7 @@ workflows:
             - scheme: $BITRISE_SCHEME
             - configuration: $BITRISE_CONFIGURATION
             - sign_uitest_targets: $SIGN_UITEST_TARGET
+            - register_test_devices: $REGISTER_TEST_DEVICES
             - keychain_path: $BITRISE_KEYCHAIN_PATH
             - keychain_password: $BITRISE_KEYCHAIN_PASSWORD
             - verbose_log: "yes"

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func downloadFile(httpClient *http.Client, src string) ([]byte, error) {
 	return contents, nil
 }
 
-func needToRegisterDevices(distrTypes []autoprovision.DistributionType) bool {
+func distributionTypeRequiresDeviceList(distrTypes []autoprovision.DistributionType) bool {
 	for _, distrType := range distrTypes {
 		if distrType == autoprovision.Development || distrType == autoprovision.AdHoc {
 			return true
@@ -587,7 +587,7 @@ func main() {
 	// Ensure devices
 	var devices []appstoreconnect.Device
 
-	if stepConf.RegisterTestDevices && needToRegisterDevices(distrTypes) {
+	if distributionTypeRequiresDeviceList(distrTypes) {
 		fmt.Println()
 		log.Infof("Fetching test devices")
 
@@ -602,7 +602,7 @@ func main() {
 			log.Debugf("- %s, %s, UDID (%s), ID (%s)", d.Attributes.Name, d.Attributes.DeviceClass, d.Attributes.UDID, d.ID)
 		}
 
-		if conn != nil && len(conn.TestDevices) != 0 {
+		if stepConf.RegisterTestDevices && conn != nil && len(conn.TestDevices) != 0 {
 			log.Infof("Checking if %d Bitrise test device(s) are registered on Developer Portal", len(conn.TestDevices))
 			for _, d := range conn.TestDevices {
 				log.Debugf("- %s, %s, UDID (%s), added at %s", d.Title, d.DeviceType, d.DeviceID, d.UpdatedAt)
@@ -678,7 +678,7 @@ func main() {
 		profileType := platformProfileTypes[distrType]
 
 		var deviceIDs []string
-		if stepConf.RegisterTestDevices && needToRegisterDevices([]autoprovision.DistributionType{distrType}) {
+		if distributionTypeRequiresDeviceList([]autoprovision.DistributionType{distrType}) {
 			for _, d := range devices {
 				if strings.HasPrefix(string(profileType), "TVOS") && d.Attributes.DeviceClass != "APPLE_TV" {
 					log.Debugf("dropping device %s, since device type: %s, required device type: APPLE_TV", d.ID, d.Attributes.DeviceClass)

--- a/main.go
+++ b/main.go
@@ -587,7 +587,7 @@ func main() {
 	// Ensure devices
 	var devices []appstoreconnect.Device
 
-	if needToRegisterDevices(distrTypes) {
+	if stepConf.RegisterTestDevices && needToRegisterDevices(distrTypes) {
 		fmt.Println()
 		log.Infof("Fetching test devices")
 
@@ -678,7 +678,7 @@ func main() {
 		profileType := platformProfileTypes[distrType]
 
 		var deviceIDs []string
-		if needToRegisterDevices([]autoprovision.DistributionType{distrType}) {
+		if stepConf.RegisterTestDevices && needToRegisterDevices([]autoprovision.DistributionType{distrType}) {
 			for _, d := range devices {
 				if strings.HasPrefix(string(profileType), "TVOS") && d.Attributes.DeviceClass != "APPLE_TV" {
 					log.Debugf("dropping device %s, since device type: %s, required device type: APPLE_TV", d.ID, d.Attributes.DeviceClass)

--- a/step.yml
+++ b/step.yml
@@ -140,6 +140,8 @@ inputs:
       title: Should the step register test devices with the Apple Developer Portal?
       description:
         If set the step will register known test devices from team members with the Apple Developer Portal.
+
+        Note that setting this to "yes" may cause devices to be registered against your limited quantity of test devices in the Apple Developer Portal, which can only be removed once annually during your renewal window.
       value_options:
         - "yes"
         - "no"

--- a/step.yml
+++ b/step.yml
@@ -138,7 +138,7 @@ inputs:
   - register_test_devices: "no"
     opts:
       title: Should the step register test devices with the Apple Developer Portal?
-      description:
+      description: |-
         If set the step will register known test devices from team members with the Apple Developer Portal.
 
         Note that setting this to "yes" may cause devices to be registered against your limited quantity of test devices in the Apple Developer Portal, which can only be removed once annually during your renewal window.

--- a/step.yml
+++ b/step.yml
@@ -135,6 +135,14 @@ inputs:
       value_options:
         - "yes"
         - "no"
+  - register_test_devices: "no"
+    opts:
+      title: Should the step register test devices with the Apple Developer Portal?
+      description:
+        If set the step will register known test devices from team members with the Apple Developer Portal.
+      value_options:
+        - "yes"
+        - "no"
   - min_profile_days_valid: 0
     opts:
       title: The minimum days the Provisioning Profile should be valid


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MAJOR_ [version update](https://semver.org/)

### Context

The step currently automatically registers all test devices known to Bitrise with the Apple Developer Portal. 

While it is understood that the step is trying to be helpful, this can have some bad consequences. Consider the Bitrise customer with a large distributed team. Bitrise has been collecting device UDIDs for years as various people try to install builds from Bitrise. Many of these devices may no longer be in use. Now recall that once a device is added to the portal, it cannot be removed except during the annual membership renewal cycle. Also recall that there are a limited number of test device slots per Apple membership, and that large companies already struggle to stay within these limits. A single Bitrise build can register dozens of unwanted devices with the Apple Developer Portal, and these slots cannot be freed up for up to a year. 

Due to the challenges discussed above I think this behavior should be configurable and default to `no`. 


### Changes

Added a new configuration option `register_test_devices`, which defaults to `no`. 

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/601312/127225183-39db222c-9762-4247-a9e2-722252e21b07.png">


### Investigation details

The suggested workaround was 

> If you want you can remove a user who has devices in their profile and ask them to remove those before adding them back into the App's Team.

This does not scale with a large distributed team where employees with mixed roles have used Bitrise over the years. 
