### PR TITLE
Adding retry for Apple Connection fetch

### DIFF
--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/httputil"
 	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/retry"
 	"github.com/google/go-querystring/query"
 )
 
@@ -78,7 +79,7 @@ func (c *RetryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
 
 // NewRetryableHTTPClient create a new http client with retry settings.
 func NewRetryableHTTPClient() *RetryableHTTPClient {
-	client := retryablehttp.NewClient()
+	client := retry.NewHTTPClient()
 	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
 			log.Debugf("Received HTTP 401 (Unauthorized), retrying request...")

--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -62,23 +62,8 @@ type Client struct {
 	Provisioning *ProvisioningService
 }
 
-// RetryableHTTPClient wraps a retryablehttp.Client and implements HTTPClient interface.
-type RetryableHTTPClient struct {
-	client *retryablehttp.Client
-}
-
-// Do ...
-func (c *RetryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	r, err := retryablehttp.FromRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.client.Do(r)
-}
-
 // NewRetryableHTTPClient create a new http client with retry settings.
-func NewRetryableHTTPClient() *RetryableHTTPClient {
+func NewRetryableHTTPClient() *http.Client {
 	client := retry.NewHTTPClient()
 	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
@@ -93,7 +78,7 @@ func NewRetryableHTTPClient() *RetryableHTTPClient {
 
 		return shouldRetry, err
 	}
-	return &RetryableHTTPClient{client: client}
+	return client.StandardClient()
 }
 
 // NewClient creates a new client
@@ -176,7 +161,7 @@ func (c *Client) NewRequest(method, endpoint string, body interface{}) (*http.Re
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	if _, ok := c.client.(*RetryableHTTPClient); ok {
+	if _, ok := c.client.(*http.Client); ok {
 		signedToken, err := c.ensureSignedToken()
 		if err != nil {
 			return nil, fmt.Errorf("ensuring JWT token failed: %v", err)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/appstoreconnect"
 	"github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/autoprovision"
 	"github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/keychain"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 // downloadCertificates downloads and parses a list of p12 files
@@ -379,7 +380,7 @@ func main() {
 
 	var devportalConnectionProvider *devportalservice.BitriseClient
 	if stepConf.BuildURL != "" && stepConf.BuildAPIToken != "" {
-		devportalConnectionProvider = devportalservice.NewBitriseClient(http.DefaultClient, stepConf.BuildURL, stepConf.BuildAPIToken)
+		devportalConnectionProvider = devportalservice.NewBitriseClient(retryablehttp.NewClient().StandardClient(), stepConf.BuildURL, stepConf.BuildAPIToken)
 	} else {
 		fmt.Println()
 		log.Warnf("Connected Apple Developer Portal Account not found. Step is not running on bitrise.io: BITRISE_BUILD_URL and BITRISE_BUILD_API_TOKEN envs are not set")

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/appstoreconnect"
 	"github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/autoprovision"
 	"github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/keychain"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 // downloadCertificates downloads and parses a list of p12 files
@@ -380,7 +379,7 @@ func main() {
 
 	var devportalConnectionProvider *devportalservice.BitriseClient
 	if stepConf.BuildURL != "" && stepConf.BuildAPIToken != "" {
-		devportalConnectionProvider = devportalservice.NewBitriseClient(retryablehttp.NewClient().StandardClient(), stepConf.BuildURL, stepConf.BuildAPIToken)
+		devportalConnectionProvider = devportalservice.NewBitriseClient(retry.NewHTTPClient().StandardClient(), stepConf.BuildURL, stepConf.BuildAPIToken)
 	} else {
 		fmt.Println()
 		log.Warnf("Connected Apple Developer Portal Account not found. Step is not running on bitrise.io: BITRISE_BUILD_URL and BITRISE_BUILD_API_TOKEN envs are not set")
@@ -407,7 +406,7 @@ func main() {
 	httpClient := appstoreconnect.NewRetryableHTTPClient()
 	client := appstoreconnect.NewClient(httpClient, authConfig.APIKey.KeyID, authConfig.APIKey.IssuerID, []byte(authConfig.APIKey.PrivateKey))
 
-	// Turn off client debug logs includeing HTTP call debug logs
+	// Turn off client debug logs including HTTP call debug logs
 	client.EnableDebugLogs = false
 
 	log.Donef("the client created for %s", client.BaseURL)


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Adding retry to API calls fetching Apple Developer connection.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
