### PR TITLE
Use apple_id evereywhere

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,7 +17,7 @@ type CertificateFileURL struct {
 
 // Config holds the step inputs
 type Config struct {
-	BitriseConnection string          `env:"connection,opt[automatic,api_key,off,enterprise-with-apple-id,apple_id]"`
+	BitriseConnection string          `env:"connection,opt[automatic,api_key,off,enterprise_with_apple_id,enterprise-with-apple-id,apple_id,apple-id]"`
 	APIKeyPath        stepconf.Secret `env:"api_key_path"`
 	APIIssuer         string          `env:"api_issuer"`
 	// Apple ID
@@ -94,7 +94,7 @@ func parseAuthSources(bitriseConnection string) ([]appleauth.Source, error) {
 		return []appleauth.Source{
 			&appleauth.ConnectionAPIKeySource{},
 		}, nil
-	case "apple_id", "enterprise-with-apple-id":
+	case "apple_id", "apple-id", "enterprise_with_apple_id", "enterprise-with-apple-id":
 		return []appleauth.Source{
 			&appleauth.ConnectionAppleIDFastlaneSource{},
 		}, nil

--- a/step.yml
+++ b/step.yml
@@ -68,14 +68,14 @@ inputs:
         - `automatic`: The Step can use either method: It will attempt to use the Bitrise Apple Developer connection first. If this is not available, it will use the Step input variables.
         - `api_key`: The Step will only use the Bitrise Apple Developer connection. It will not use the Step input variables.
         - `off`: The Step will only use the Step input variables. It will not use the Bitrise Apple Developer connection.
-        - `enterprise-with-apple-id`: [Bitrise Apple Service connection with an Apple Developer Enterpsie account.](https://devcenter.bitrise.io/getting-started/connecting-to-services/connecting-to-an-apple-service-with-apple-id/)
+        - `enterprise_with_apple_id`: [Bitrise Apple Service connection with an Apple Developer Enterpsie account.](https://devcenter.bitrise.io/getting-started/connecting-to-services/connecting-to-an-apple-service-with-apple-id/)
         - `apple_id`: [Bitrise Apple Service connection with Apple ID.](https://devcenter.bitrise.io/getting-started/connecting-to-services/connecting-to-an-apple-service-with-apple-id/)
       is_required: true
       value_options:
       - "automatic"
       - "api_key"
       - "off"
-      - "enterprise-with-apple-id"
+      - "enterprise_with_apple_id"
       - "apple_id"
   - api_key_path: ""
     opts:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Selecting `apple-id` in the workflow editor did not work earlier, due to a casing mismatch.

Replaced `apple-id` with `apple_id` in step.yml. (And `enterprise-with-apple-id` with `enterprise_with_apple_id`, for consistently using snake case).
`enterprise-with-apple-id` will continue to work in existing workflows, for backwards compatibility. (`apple-id` also works)


https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/issues/76

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
