### PR TITLE
Add ParentApplicationIdentifiers to list of capabilities not present on AppstoreConnect API

### DIFF
--- a/autoprovision/entitlements.go
+++ b/autoprovision/entitlements.go
@@ -106,7 +106,7 @@ func (e Entitlement) AppearsOnDeveloperPortal() bool {
 	entKey := serialized.Object(e).Keys()[0]
 
 	capType, ok := appstoreconnect.ServiceTypeByKey[entKey]
-	return ok && capType != appstoreconnect.Ignored && capType != appstoreconnect.ProfileAttachedEntitlement
+	return ok && capType != appstoreconnect.Ignored && capType != appstoreconnect.ProfileAttachedEntitlement && capType != appstoreconnect.ParentApplicationIdentifiers
 }
 
 // Equal ...


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a PATCH [version update](https://semver.org/)

### Context

This change fixes the auto-provision step to work with projects that contain an App Clip. 

Resolves #72 

### Changes

The ParentApplicationIdentifiers capability type was added to the list of capabilities that do not appear in the AppstoreConnect API. 

### Investigation details

If a project contains an App Clip, the auto-provision step currently fails with this error: 

```
Searching for app ID for bundle ID: com.example.App.Clip
  app ID found: XC com Example App Clip
  app ID capabilities invalid: bundle ID missing Capability (ODIC_PARENT_BUNDLEID) required by project Entitlement (com.apple.developer.parent-application-identifiers)
  app ID capabilities are not in sync with the project capabilities, synchronizing...
failed to update bundle ID capabilities: step does not support creating an application identifier using the "Parent Bundle ID" capability, please add your Application Identifier manually using the Apple Developer Portal
```

It seems that the AppstoreConnect API has not been properly updated to support App Clips. 

These are the Bundle ID capabilities returned by the API for an App Clip Identifier: 

```
GAME_CENTER
IN_APP_PURCHASE
ON_DEMAND_INSTALL_CAPABLE
ASSOCIATED_DOMAINS
APP_GROUPS
```

Note the absence of `ODIC_PARENT_BUNDLEID`.

After the change in this PR is applied, the auto-provision step successfully generates provisioning profiles for App Clips. 

This change could likely be reverted if/when the AppstoreConnect API is updated to support App Clips.

### Decisions

<!-- Please list decisions that were made for this change. -->
