### PR TITLE
Add e2e test case for App Clip target.

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -37,7 +37,7 @@ workflows:
   utility_test_appclip:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/Fruta.git
-    - TEST_APP_BRANCH: update-sample
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: Fruta.xcodeproj
     - BITRISE_SCHEME: Fruta iOS
     - SIGN_UITEST_TARGET: "no"


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

[Previous contribution](https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/pull/79) resolved the issue that the step fails if the project contains an App Clip target.

This PR adds a new e2e test case to make sure the issue does not appear as long as the Application Identifier of the App Clip target is in sync with the project capabilities.

### Changes

- add new e2e test case with a sample project having App Clip target
- removed `test_xcode_managed` as new `test_appclip` also uses Xcode project with Xcode managed code signing
- removed `test_workspace` as both `test_tvos` and `test_tvos_development` uses Xcode project with workspace

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
