### PR TITLE
Wire in SignUITestTargets input.

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 		failf(err.Error())
 	}
 
-	appLayout, err := project.GetAppLayout(true)
+	appLayout, err := project.GetAppLayout(cfg.SignUITestTargets)
 	if err != nil {
 		failf(err.Error())
 	}


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

`sign_uitest_targets` input is ignored by the Step.

Resolves: https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/issues/82

### Changes

- Use `sign_uitest_targets` input to configure `project.GetAppLayout`

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
