### PR TITLE
Update go-xcode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/bitrise-io/go-steputils v0.0.0-20211205220451-e046db274afb
 	github.com/bitrise-io/go-utils v0.0.0-20211126092127-3a566ee3f420
-	github.com/bitrise-io/go-xcode v0.0.0-20211217002218-2be2d78bc261
+	github.com/bitrise-io/go-xcode v0.0.0-20211217145509-40f912f04ad6
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d/go.mod h1:Vi4M
 github.com/bitrise-io/go-utils v0.0.0-20211008161027-fa11986847a0/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
 github.com/bitrise-io/go-utils v0.0.0-20211126092127-3a566ee3f420 h1:cbKXuIhwfZzPgvuSCvEtmWxBWSk70Vivj78cOMVWgUg=
 github.com/bitrise-io/go-utils v0.0.0-20211126092127-3a566ee3f420/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
-github.com/bitrise-io/go-xcode v0.0.0-20211217002218-2be2d78bc261 h1:6HYagzItoQyA7WkfEdk3AUYpr0NE5h6eIWKYKTJwRn0=
-github.com/bitrise-io/go-xcode v0.0.0-20211217002218-2be2d78bc261/go.mod h1:Ptio5Y5KeEmLM78dB/atcOl6nXPNDpY0IZF8DwFlBpk=
+github.com/bitrise-io/go-xcode v0.0.0-20211217145509-40f912f04ad6 h1:mkRImUBUMTarCQ7DX/0spCrPD5zU3Jy25geLg9IgNR0=
+github.com/bitrise-io/go-xcode v0.0.0-20211217145509-40f912f04ad6/go.mod h1:Ptio5Y5KeEmLM78dB/atcOl6nXPNDpY0IZF8DwFlBpk=
 github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630 h1:V+xoYqGSkN8aUxCc806zDKjGGpBVUtV0Vytf5OsB3gc=
 github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/bitrise-io/go-xcode/autocodesign/devportalclient/appstoreconnect/time.go
+++ b/vendor/github.com/bitrise-io/go-xcode/autocodesign/devportalclient/appstoreconnect/time.go
@@ -1,6 +1,7 @@
 package appstoreconnect
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
@@ -11,10 +12,35 @@ type Time time.Time
 // UnmarshalJSON ...
 func (t *Time) UnmarshalJSON(b []byte) error {
 	timeStr := strings.Trim(string(b), `"`)
-	parsed, err := time.Parse("2006-01-02T15:04:05.000-07:00", timeStr)
-	if err != nil {
-		return err
+	var errors []error
+
+	for _, timeFormat := range timeFormats() {
+		parsed, err := time.Parse(timeFormat, timeStr)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		*t = Time(parsed)
+		return nil
 	}
-	*t = Time(parsed)
-	return nil
+
+	return fmt.Errorf("%s", errors)
+}
+
+func timeFormats() []string {
+	// Apple is using an ISO 8601 time format (https://en.wikipedia.org/wiki/ISO_8601). In this format the offset from
+	// the UTC time can have the following equivalent and interchangeable formats:
+	// * [+/-]07:00
+	// * [+/-]0700
+	// * [+/-]07
+	// (* also if there is no UTC offset then [+0000, +00:00, +00] are the same as adding a Z after the seconds)
+	//
+	// Go has built in support for ISO 8601 but only for the zero offset UTC and the [+/-]07:00 format under time.RFC3339.
+	// We still need to check for the other two.
+	return []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05.000-0700",
+		"2006-01-02T15:04:05.000-07",
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -22,7 +22,7 @@ github.com/bitrise-io/go-utils/pointers
 github.com/bitrise-io/go-utils/pretty
 github.com/bitrise-io/go-utils/retry
 github.com/bitrise-io/go-utils/sliceutil
-# github.com/bitrise-io/go-xcode v0.0.0-20211217002218-2be2d78bc261
+# github.com/bitrise-io/go-xcode v0.0.0-20211217145509-40f912f04ad6
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/autocodesign


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a minor [version update](https://semver.org/)

### Context

Update the go-xcode library to pull in a more flexible appstoreconnect api time value parsing.